### PR TITLE
In gen-pkgs-list.jl, pull dependencies automatically

### DIFF
--- a/gen-pkgs-list.jl
+++ b/gen-pkgs-list.jl
@@ -8,6 +8,9 @@
 # Imports
 #--------------------------------------------------
 
+using Pkg
+Pkg.activate(".")
+Pkg.instantiate()
 include("src/JuliaPkgsList.jl")
 using Main.JuliaPkgsList
 


### PR DESCRIPTION
This seems to be a more robust way of pulling in dependencies: user doesn't have to take care of them manually. Startup time doesn't seem to be hurt significantly (I did not run benchmarks, but visually it seems the same).